### PR TITLE
fix(ci): pin build matrix toolchain to 1.95.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: "1.95.0"
+          components: clippy, rustfmt
           targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies


### PR DESCRIPTION
## Summary
- Build matrix in `release.yml` installed `stable` toolchain via `dtolnay/rust-toolchain`, but `rust-toolchain.toml` pins channel `1.95.0`. Targets were added to `stable`, then cargo activated `1.95.0` without the cross-compilation target → `error[E0463]: can't find crate for core` on `x86_64-apple-darwin`.
- `fail-fast` cancelled the other archs, so v1.1.0 was published with zero binary assets — `install.sh` 404s on every platform.
- Fix: pass `toolchain: "1.95.0"` and `components: clippy, rustfmt` to the action so the matrix target is installed against the toolchain cargo actually uses.

## Test plan
- [ ] CI `Lint & Test` job green
- [ ] Once merged: semantic-release cuts `v1.1.1`
- [ ] All three matrix `Build` jobs succeed
- [ ] `v1.1.1` release contains `pvm-linux-x86_64.tar.gz`, `pvm-macos-aarch64.tar.gz`, `pvm-macos-x86_64.tar.gz`
- [ ] `curl -fsSL https://raw.githubusercontent.com/WebProject-xyz/php-version-manager/main/install.sh | bash` succeeds on macOS aarch64 (issue #20 reproducer)

Fixes #20