### PR TITLE
fix(ci): pass App token via 'token' input to action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,5 +138,4 @@ jobs:
         with:
           tag_name: v${{ needs.release.outputs.new_release_version }}
           files: ${{ matrix.asset_name }}.tar.gz
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary
- Toolchain pin from #21 worked: matrix builds compile. But asset upload still failed with `Resource not accessible by integration` (403). v1.1.1 release was published with **zero** binaries.
- Root cause: `softprops/action-gh-release@v2.6.1` (per softprops/action-gh-release#751) now prefers the explicit `token:` input over the `GITHUB_TOKEN` env var. Action default is `token: ${{ github.token }}` — the workflow GITHUB_TOKEN, not the GitHub App token we want. Build job has no `permissions:` block, so the workflow token has no release write perms.
- Fix: pass the App token via `token:` input. Drop the now-redundant `env: GITHUB_TOKEN`.
- Once merged, semantic-release cuts v1.1.2 with all three tarballs and `install.sh` recovers automatically.

## Test plan
- [ ] CI `Lint & Test` passes
- [ ] On merge: semantic-release publishes `v1.1.2`
- [ ] All three matrix `Build` jobs succeed and upload assets
- [ ] `v1.1.2` release contains `pvm-linux-x86_64.tar.gz`, `pvm-macos-aarch64.tar.gz`, `pvm-macos-x86_64.tar.gz`
- [ ] `curl -fsSL https://raw.githubusercontent.com/WebProject-xyz/php-version-manager/main/install.sh | bash` succeeds on macOS aarch64 (issue #20 reproducer)

Refs #20